### PR TITLE
PAAC-162: Support £0 in pension input page.

### DIFF
--- a/app/controllers/PensionInputsController.scala
+++ b/app/controllers/PensionInputsController.scala
@@ -40,18 +40,17 @@ trait PensionInputsController  extends BaseFrontendController {
     keystore.read[String](key).map {
         (amount) =>
         val fields = Map(amount match {
-          case None => (key, "0.00")
+          case None => (key, "")
           case Some("0") => (key, "0.00")
-          case Some(value) => (key, (value.toInt/100.00).toString)
+          case Some(value) => (key, f"${(value.toInt/100.00)}%2.2f")
         })
-        Ok(views.html.pensionInputs(PensionInputForm.form.bind(fields)))
+        Ok(views.html.pensionInputs(PensionInputForm.form.bind(fields).discardingErrors))
     }
   }
 
   val onSubmit = withSession { implicit request =>
-
     PensionInputForm.form.bindFromRequest().fold(
-      formWithErrors => { Future.successful(Ok(views.html.pensionInputs(PensionInputForm.form))) },
+      formWithErrors => { Future.successful(Ok(views.html.pensionInputs(formWithErrors))) },
       input => {
         val (amount:Long, key:String) = input.toDefinedBenefit(2014).getOrElse(("definedBenefit_2014", 0L))
         keystore.store[String](amount.toString, key)

--- a/app/controllers/ReviewTotalAmountsController.scala
+++ b/app/controllers/ReviewTotalAmountsController.scala
@@ -38,9 +38,10 @@ trait ReviewTotalAmountsController extends BaseFrontendController {
   private def fetchAmounts()(implicit hc: HeaderCarrier, request: Request[AnyContent]): Future[Map[String,String]] = {
     def fetchAmount(key: String) : Future[Option[(String,String)]] = keystore.read[String](key).map { (amount) =>
         amount match {
-          case None => Some((key, "0.00"))
+          case None => None
+          case Some("-1") => Some((key, "0.00"))
           case Some("0") => Some((key, "0.00"))
-          case Some(value) => Some((key, (value.toInt/100.00).toString))
+          case Some(value) => Some((key, f"${(value.toInt/100.00)}%2.2f"))
         }
       }
     def fetchYearAmounts(year: Int) : List[Future[Option[(String,String)]]] = year match {

--- a/app/form/CalculatorForm.scala
+++ b/app/form/CalculatorForm.scala
@@ -25,22 +25,25 @@ import play.api.data.validation._
 import play.api.i18n.Messages
 
 /* Really horrible to have repeated fields however this will change shortly due to mini-tax years and tax periods. */
-case class CalculatorFormFields(amount2008:BigDecimal=0,
-                                amount2009:BigDecimal=0,
-                                amount2010:BigDecimal=0,
-                                amount2011:BigDecimal=0,
-                                amount2012:BigDecimal=0,
-                                amount2013:BigDecimal=0,
-                                amount2014:BigDecimal=0) {
+case class CalculatorFormFields(amount2006:Option[BigDecimal]=None,
+                                amount2007:Option[BigDecimal]=None,
+                                amount2008:Option[BigDecimal]=None,
+                                amount2009:Option[BigDecimal]=None,
+                                amount2010:Option[BigDecimal]=None,
+                                amount2011:Option[BigDecimal]=None,
+                                amount2012:Option[BigDecimal]=None,
+                                amount2013:Option[BigDecimal]=None,
+                                amount2014:Option[BigDecimal]=None) {
   def toContributions():List[Contribution] = {
-    List(Contribution(2008,(amount2008*100).longValue),
-         Contribution(2009,(amount2009*100).longValue),
-         Contribution(2010,(amount2010*100).longValue),
-         Contribution(2011,(amount2011*100).longValue),
-         Contribution(2012,(amount2012*100).longValue),
-         Contribution(2013,(amount2013*100).longValue),
-         Contribution(2014,(amount2014*100).longValue)
-         )
+    def toPence(maybeAmount: Option[BigDecimal]) : Long = maybeAmount.map((v:BigDecimal)=>(v*100).longValue).getOrElse(0)
+
+    val currentYear = (new java.util.GregorianCalendar()).get(java.util.Calendar.YEAR)
+    val fieldValueMap: Map[String,Any]= this.getClass.getDeclaredFields.map(_.getName).zip(this.productIterator.toList).toMap
+    val maybeContributions = List.range(2008, currentYear).map {
+      (year:Int) =>
+      fieldValueMap.get("amount"+year).map((v:Any)=>Contribution(year,toPence(v.asInstanceOf[Option[BigDecimal]])))
+    }
+    maybeContributions.filter(_!=None).map(_.get)
   }
 }
 
@@ -52,13 +55,15 @@ object CalculatorForm {
 
   val form: Form[CalculatorFormType] = Form(
     mapping(
-      "definedBenefit_2008" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2009" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2010" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2011" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2012" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2013" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0)),
-      "definedBenefit_2014" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0))
+      "definedBenefit_2006" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2007" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2008" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2009" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2010" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2011" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2012" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2013" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true),
+      "definedBenefit_2014" -> optional(bigDecimal(10,2)).verifying("error.bounds",value=>if (value.isDefined) value.get.longValue >= 0 && value.get.longValue < 99999999.99 else true)
     )(CalculatorFormFields.apply)(CalculatorFormFields.unapply)
   )
 }

--- a/app/form/PensionInputForm.scala
+++ b/app/form/PensionInputForm.scala
@@ -38,7 +38,7 @@ object PensionInputForm {
 
   val form: Form[PensionInputFormType] = Form(
     mapping(
-      "definedBenefit_2014" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0))
+      "definedBenefit_2014" -> bigDecimal(10,2).verifying(Constraints.min[BigDecimal](0), Constraints.max(BigDecimal(9999999.99)))
     )(PensionInputFormFields.apply)(PensionInputFormFields.unapply)
   )
 }

--- a/app/models/Contribution.scala
+++ b/app/models/Contribution.scala
@@ -23,9 +23,10 @@ import play.api.libs.json._
 sealed trait CalculationParam
 sealed trait PensionCalculatorValue
 
-case class InputAmounts(definedBenefit: Long = 0, moneyPurchase: Long = 0) extends PensionCalculatorValue {
+case class InputAmounts(definedBenefit: Long = -1, moneyPurchase: Long = -1) extends PensionCalculatorValue {
   def isEmpty() : Boolean = {
-    definedBenefit == 0 && moneyPurchase == 0
+    // users may enter values of 0 so using -1 should create new type for empty rather than option
+    definedBenefit == -1 && moneyPurchase == -1
   }
 }
 case class TaxPeriod(year: Int, month: Int, day: Int)
@@ -80,6 +81,6 @@ object Contribution {
   )(Contribution.apply(_:TaxPeriod, _:TaxPeriod, _:InputAmounts))
 
   def apply(year: Int, definedBenefit: Long) : Contribution = {
-    Contribution(TaxPeriod(year, 4, 6), TaxPeriod(year+1, 4, 5), InputAmounts(definedBenefit=definedBenefit))
+    Contribution(TaxPeriod(year, 4, 6), TaxPeriod(year+1, 4, 5), InputAmounts(definedBenefit=definedBenefit,moneyPurchase=0))
   }
 }

--- a/app/views/pensionInputs.scala.html
+++ b/app/views/pensionInputs.scala.html
@@ -12,6 +12,33 @@ backLink = Some((controllers.routes.SelectSchemeController.onPageLoad.url,Messag
     <p class="lede text">@Messages("paac.calculator.startpage.p1")</p>
     <p class="lede text">@Messages("paac.calculator.startpage.p2")</p>
 
+    @if(paacForm.hasErrors) {
+      <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1" style="border: 5px solid #b10e1e;padding: 20px;padding-top: 0px;margin-bottom: 30px;">
+
+        <h1 class="heading-medium error-summary-heading">
+          There was a problem with the amounts you reported to us
+        </h1>
+
+        @if(paacForm.hasGlobalErrors) {
+          <ul>
+          @for(error <- paacForm.globalErrors) {
+            <li>@error.message</li>
+          }
+          </ul>
+        }
+
+        <ul class="error-summary-list">
+          @for(error <- paacForm.errors) {
+            @defining(error.key.drop(15).toInt) { year =>
+              @defining(Seq(models.Contribution(year,0).taxYearLabel())++error.args) { args =>
+                <li><a href="#input_@year" style="color:#b10e1e;font-weight: bold;">@Messages(error.message, args:_*)</a></li>
+              }
+            }
+          }
+        </ul>
+      </div>
+    }
+    
     @form(
         action = controllers.routes.PensionInputsController.onSubmit,
         args = 'class -> "form", 'autocomplete -> "off", 'novalidate -> "") {
@@ -20,9 +47,9 @@ backLink = Some((controllers.routes.SelectSchemeController.onPageLoad.url,Messag
         <table>
             <thead>
                 <tr>
-                    <th class="numeric" scope="col" style="text-align: right">Tax years</th>
-                    <th class="numeric" scope="col" style="text-align: right"></th>
-                    <th class="numeric" scope="col" style="text-align: right">Pension input amount value</th>
+                    <th class="numeric" scope="col" style="text-align: left">Tax years</th>
+                    <th class="numeric" scope="col" style="text-align: left"></th>
+                    <th class="numeric" scope="col" style="text-align: left">Pension input amount value</th>
                 </tr>
             </thead>
             <tbody>
@@ -31,17 +58,17 @@ backLink = Some((controllers.routes.SelectSchemeController.onPageLoad.url,Messag
                 @for(i <- List(2014)) {
                 <fieldset id="input_@i" class="form-field-group" style="max-width:12.35em;">
                     <label class="form-element-bold label--full-length numeric" for="definedBenefit_@i" style="width:150%;display: inline-block;@if(paacForm.errors.find(_.key == "definedBenefit_"+i)) {color:#b10e1e;}">
-                    <td style="text-align:right;min-width: 7em">@(Contribution(i,0).taxYearLabel())</td>
-                    <td style="text-align:right;min-width: 7em">Total Defined Benefit</td>
+                    <td style="text-align:left;min-width: 7em">@(Contribution(i,0).taxYearLabel())</td>
+                    <td style="text-align:left;min-width: 7em">Total Defined Benefit</td>
 
                       <span style="float:right">
                       @if(paacForm.data.contains("definedBenefit_"+i)) {
-                          <td style="text-align:right;min-width: 7em">
+                          <td style="text-align:left;min-width: 7em">
                               £&nbsp;<input type="number" name="definedBenefit_@i" id="definedBenefit" min="0" step="1" value='@paacForm.data("definedBenefit_"+i)' max="9999999.99" size="10" style="width:9em;@if(paacForm.errors.find(_.key == "definedBenefit_"+i)) {border: 4px solid #b10e1e;}"/>
                           </td>
                           } else {
-                          <td style="text-align:right;min-width: 7em">
-                              £&nbsp;<input type="number" name="definedBenefit_@i" id="definedBenefit" min="0" step="1" value='0.00' max="9999999.99" size="10" style="width:9em;@if(paacForm.errors.find(_.key == "definedBenefit_"+i)) {border: 4px solid #b10e1e;}"/>
+                          <td style="text-align:left;min-width: 7em">
+                              £&nbsp;<input type="number" name="definedBenefit_@i" id="definedBenefit" min="0" step="1" value='' max="9999999.99" size="10" style="width:9em;@if(paacForm.errors.find(_.key == "definedBenefit_"+i)) {border: 4px solid #b10e1e;}"/>
                           </td>
                           }
                       </span>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -24,7 +24,7 @@ backLink = Some((controllers.routes.ReviewTotalAmountsController.onPageLoad.url,
        <tbody>
   @results.map { result =>
     @defining(java.text.NumberFormat.getCurrencyInstance(java.util.Locale.UK)) { currencyFormatter =>
-      @if(!result.isEmpty()) {
+      @if(result.input.taxPeriodStart.year == 2014) {
        <tr>
           <td>@result.input.taxYearLabel</td>
           <td class="numeric">@(currencyFormatter.format(result.input.amounts.definedBenefit/100.00))</td>

--- a/app/views/review_amounts.scala.html
+++ b/app/views/review_amounts.scala.html
@@ -11,6 +11,34 @@ articleClasses = Some("full-width"),
 backLink = Some((controllers.routes.PensionInputsController.onPageLoad.url,Messages("paac.link.text.back")))
 ) {
         <p class="lede text">@Messages("paac.review-amounts.paragraph")</p>
+
+    @if(reviewForm.hasErrors) {
+      <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1" style="border: 5px solid #b10e1e;padding: 20px;padding-top: 0px;margin-bottom: 30px;">
+
+        <h1 class="heading-medium error-summary-heading">
+          There was a problem with the amounts you reported to us
+        </h1>
+
+        @if(reviewForm.hasGlobalErrors) {
+          <ul>
+          @for(error <- reviewForm.globalErrors) {
+            <li>@error.message</li>
+          }
+          </ul>
+        }
+
+        <ul class="error-summary-list">
+          @for(error <- reviewForm.errors) {
+            @defining(error.key.drop(15).toInt) { year =>
+              @defining(Seq(models.Contribution(year,0).taxYearLabel())++error.args) { args =>
+                <li><a href="#input_@year" style="color:#b10e1e;font-weight: bold;">@Messages(error.message, args:_*)</a></li>
+              }
+            }
+          }
+        </ul>
+      </div>
+    }
+    
         <table>
           <thead>
             <tr>
@@ -18,29 +46,29 @@ backLink = Some((controllers.routes.PensionInputsController.onPageLoad.url,Messa
               <th class="numeric" scope="col">@Messages("paac.review-amounts.heading.db")</th>
               <th class="numeric" scope="col">@Messages("paac.review-amounts.heading.mp")</th>
               <th class="numeric" scope="col">@Messages("paac.review-amounts.heading.ta")</th>
-              <th></th>
+              <th class="edit_action" scope="col"></th>
             </tr>
           </thead>
           <tbody>
 @defining(java.text.NumberFormat.getCurrencyInstance(java.util.Locale.UK)) { currencyFormatter =>  
   @for(i <- List.range(2006, (new java.util.GregorianCalendar()).get(java.util.Calendar.YEAR)).reverse) {
-    @defining(new BigDecimal(reviewForm.data.getOrElse("definedBenefit_"+i,"0.0"))) { db =>
-    @defining(new BigDecimal(reviewForm.data.getOrElse("moneyPurchase_"+i,"0.0"))) { mp =>
-    @defining(new BigDecimal(reviewForm.data.getOrElse("taperedAllowance_"+i,"0.0"))) { ta =>
-    @if(db.intValue() > 0 || ta.intValue() > 0 || mp.intValue() > 0) {
-      <tr style="@if(reviewForm.errors.find(_.key == "definedBenefit_"+i) || 
+    @defining(new BigDecimal(reviewForm.data.getOrElse("definedBenefit_"+i,"-1.0"))) { db =>
+    @defining(new BigDecimal(reviewForm.data.getOrElse("moneyPurchase_"+i,"-1.0"))) { mp =>
+    @defining(new BigDecimal(reviewForm.data.getOrElse("taperedAllowance_"+i,"-1.0"))) { ta =>
+    @if(db.intValue() >= 0 || ta.intValue() >= 0 || mp.intValue() >= 0) {
+      <tr class="@if(reviewForm.errors.find(_.key == "definedBenefit_"+i) || 
                      reviewForm.errors.find(_.key == "moneyPurchase_"+i) ||
-                     reviewForm.errors.find(_.key == "taperedAllowance_"+i)) {color:#b10e1e;}">
+                     reviewForm.errors.find(_.key == "taperedAllowance_"+i)) {error_color}">
         <td class="numeric">@(Contribution(i,0).taxYearLabel())</td>
         <td class="numeric">
-          @if(db.intValue() > 0){
+          @if(db.intValue() >= 0){
             @(currencyFormatter.format(db))
           } else {
             &pound;&nbsp;&ndash;
           } 
         </td>
         <td class="numeric">@if(i > 2014) {
-          @if(mp.intValue() > 0){
+          @if(mp.intValue() >= 0){
             @(currencyFormatter.format(mp))
           } else {
             &pound;&nbsp;&ndash;
@@ -50,7 +78,7 @@ backLink = Some((controllers.routes.PensionInputsController.onPageLoad.url,Messa
         }
         </td>
         <td class="numeric">@if(i > 2015) {
-          @if(ta.intValue() > 0){
+          @if(ta.intValue() >= 0){
             @(currencyFormatter.format(ta))
           } else {
             &pound;&nbsp;&ndash;

--- a/conf/messages
+++ b/conf/messages
@@ -32,7 +32,9 @@ paac.calculator.form.error = This field is required
 paac.calculator.error.number=Use whole numbers only, not decimals or characters
 paac.calculator.error.number.zero= Enter a number greater than 0
 error.min={0} amount was too small and must be either £0.00 or greater.
-error.real.precision={0} amount must be not be empty. (Amount must have no more than {1} numbers, including {2} decimal places, that is it should be £0.00 or greater.)
+error.max={0} amount was too large and must be either £{1} or less.
+error.bounds={0} amount was empty. Please provide an amount between £0.00 and £99999999.99.
+error.real.precision={0} amount must be not be empty. (Amount must have no more than {1} numbers, including {2} decimal places, and should be £0.00 or larger and under £99999999.99.)
 
 
 ## Eligibility Page

--- a/public/stylesheets/paac.css
+++ b/public/stylesheets/paac.css
@@ -1,6 +1,16 @@
 #content > .full-width {
   float: left !important;
+  width: 100%;
 }
+
+.error_color {
+  color:#b10e1e;  
+}
+
+.error_border {
+
+}
+
 
 table {
   border-collapse: collapse;
@@ -89,8 +99,8 @@ table td.numeric {
 }
 
 
-#content > table > .edit_action {
-  min-width:5em;
+.edit_action {
+  min-width: 5em;
   text-align: right;
   white-space: nowrap;
 }


### PR DESCRIPTION
Adding validation to pension input controller to not allow blank values but do allow 0.
Updated model classes to support -1 which should probably be converted to optionals.
Updated stylesheet for review page edit column.
Updated messages for new out of bounds value for pension input.