### PR TITLE
PAAC-439: Carry forwards from a specified year.

### DIFF
--- a/app/connector/CalculatorConnector.scala
+++ b/app/connector/CalculatorConnector.scala
@@ -35,8 +35,9 @@ trait CalculatorConnector {
   def serviceUrl: String
 
   def connectToPAACService(contributions:List[Contribution])(implicit hc: HeaderCarrier): Future[List[TaxYearResults]] = {
+    val calculationRequest = CalculationRequest(contributions, Some(2012), Some(false))
     val endpoint = Play.current.configuration.getString("microservice.services.paac.endpoints.calculate").getOrElse("/paac/calculate")
     httpPostRequest.POST[JsValue, HttpResponse](s"${serviceUrl}${endpoint}",
-      Json.toJson(contributions)).map((response)=>(response.json \ "results").as[List[TaxYearResults]])
+      Json.toJson(calculationRequest)).map((response)=>(response.json \ "results").as[List[TaxYearResults]])
   }
 }

--- a/app/models/Request.scala
+++ b/app/models/Request.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+sealed trait BackendRequest {
+  def contributions(): List[Contribution]
+  def startFromYear():  Option[Int]
+  def missingYearsAreRegistered(): Option[Boolean]
+}
+
+case class CalculationRequest(contributions: List[Contribution], 
+                              startFromYear: Option[Int] = Some(PensionPeriod.EARLIEST_YEAR_SUPPORTED),
+                              missingYearsAreRegistered: Option[Boolean] = Some(true)) extends BackendRequest {
+}
+
+object BackendRequest {
+  implicit val requestWrites: Writes[BackendRequest] = (
+    (JsPath \ "contributions").write[List[Contribution]] and
+    (JsPath \ "startFromYear").write[Option[Int]] and
+    (JsPath \ "missingYearsAreRegistered").write[Option[Boolean]]
+  )(BackendRequest.toTuple _)
+
+  implicit val requestReads: Reads[BackendRequest] = (
+    (JsPath \ "contributions").read[List[Contribution]] and
+    (JsPath \ "startFromYear").readNullable[Int](min(PensionPeriod.EARLIEST_YEAR_SUPPORTED)) and
+    (JsPath \ "missingYearsAreRegistered").readNullable[Boolean]
+  )(BackendRequest.toRequest _)
+
+  def toTuple(request: BackendRequest): (List[Contribution], Option[Int], Option[Boolean]) = {
+    (request.contributions, request.startFromYear, request.missingYearsAreRegistered)
+  }
+
+  def toRequest(contributions: List[Contribution],
+                startFromYear: Option[Int],
+                missingYearsAreRegistered: Option[Boolean]): BackendRequest = {
+    CalculationRequest(contributions, startFromYear, missingYearsAreRegistered)
+  }
+}

--- a/test/connector/CalculatorConnectorSpec.scala
+++ b/test/connector/CalculatorConnectorSpec.scala
@@ -56,20 +56,20 @@ class CalculatorConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndA
   "Calculator connector" should {
     "convert contributions to json" in {
       // set up
-      val request = Json.toJson(CalculationRequest(List(Contribution(2008,5000)), Some(2012), Some(false)))
       implicit val hc = uk.gov.hmrc.play.http.HeaderCarrier()
       val mockHttpPost = mock[HttpPost]
       object MockCalculatorConnector extends CalculatorConnector {
         override def httpPostRequest: HttpPost = mockHttpPost
         override def serviceUrl: String = ""
       }
-      stub(mockHttpPost.POST[JsValue, HttpResponse]("/paac/calculate", request, null)).toReturn(HttpResponse(200))
+      val body = Json.toJson(CalculationRequest(List(Contribution(2008,5000)),Some(2008),Some(false)))
+      stub(mockHttpPost.POST[JsValue, HttpResponse]("/paac/calculate", body, null)).toReturn(Future.successful(HttpResponse(200)))
 
       // test
       MockCalculatorConnector.connectToPAACService(List(Contribution(2008,5000)))
 
       // check
-      verify(mockHttpPost).POST[JsValue, HttpResponse]("/paac/calculate", request, null)
+      verify(mockHttpPost).POST[JsValue, HttpResponse]("/paac/calculate", body, null)
     }
   }
 }

--- a/test/connector/CalculatorConnectorSpec.scala
+++ b/test/connector/CalculatorConnectorSpec.scala
@@ -56,19 +56,20 @@ class CalculatorConnectorSpec extends UnitSpec with MockitoSugar with BeforeAndA
   "Calculator connector" should {
     "convert contributions to json" in {
       // set up
+      val request = Json.toJson(CalculationRequest(List(Contribution(2008,5000)), Some(2012), Some(false)))
       implicit val hc = uk.gov.hmrc.play.http.HeaderCarrier()
       val mockHttpPost = mock[HttpPost]
       object MockCalculatorConnector extends CalculatorConnector {
         override def httpPostRequest: HttpPost = mockHttpPost
         override def serviceUrl: String = ""
       }
-      stub(mockHttpPost.POST[JsValue, HttpResponse]("/paac/calculate", Json.toJson(List(Contribution(2008,5000))), null)).toReturn(HttpResponse(200))
+      stub(mockHttpPost.POST[JsValue, HttpResponse]("/paac/calculate", request, null)).toReturn(HttpResponse(200))
 
       // test
       MockCalculatorConnector.connectToPAACService(List(Contribution(2008,5000)))
 
       // check
-      verify(mockHttpPost).POST[JsValue, HttpResponse]("/paac/calculate", Json.toJson(List(Contribution(2008,5000))), null)
+      verify(mockHttpPost).POST[JsValue, HttpResponse]("/paac/calculate", request, null)
     }
   }
 }

--- a/test/models/RequestSpec.scala
+++ b/test/models/RequestSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.libs.json._
+import play.api.data.validation._
+
+import org.scalatest._
+import org.scalatest.Matchers._
+import org.scalatest.OptionValues._
+
+class RequestSpec extends ModelSpec {
+  "CalculationRequest" should {
+    "have a list of contributions" in {
+      // set up
+      val contributions = List(Contribution(2010,123), Contribution(2011,456))
+
+      // check
+      CalculationRequest(contributions, None, None).contributions shouldBe (contributions)
+    }    
+
+    "have a startFromYear" in {
+      // set up
+      val contributions = List()
+
+      // check
+      CalculationRequest(contributions, Some(2015), None).startFromYear shouldBe (Some(2015))
+    }
+
+    "have a missingYearsAreRegistered" in {
+      // set up
+      val contributions = List()
+
+      // check
+      CalculationRequest(contributions, None, Some(false)).missingYearsAreRegistered shouldBe (Some(false))
+    }
+
+    "marshal to Json" in {
+      // set up
+      val contributions = List(Contribution(2010,123), Contribution(2011,456))
+      val r = CalculationRequest(contributions, Some(2012), Some(false))
+
+      // test
+      val json = Json.toJson(r)
+
+      // check
+      val jsonContributions = json \ "contributions"
+      jsonContributions.as[Seq[Contribution]] shouldBe contributions
+      val jsonStartFromYear = json \ "startFromYear"
+      jsonStartFromYear.as[Int] shouldBe 2012
+      val jsonMissingYearsAreRegistered = json \ "missingYearsAreRegistered"
+      jsonMissingYearsAreRegistered.as[Boolean] shouldBe false
+    }
+
+    "unmarshall from Json" in {
+      // set up
+      val json = Json.parse("""{"contributions": [], "startFromYear": 2012, "missingYearsAreRegistered" : false}""")
+
+      // test
+      val maybeRequest : Option[BackendRequest] = json.validate[BackendRequest].fold(invalid = { e => { println(e);None} }, valid = { r => Some(r) })
+
+      // check
+      maybeRequest shouldBe Some(CalculationRequest(List(), Some(2012), Some(false)))
+    }
+
+    "toTuple" in {
+      // set up
+      val contributions = List(Contribution(2010,123), Contribution(2011,456))
+      val r = CalculationRequest(contributions, Some(2012), Some(false))
+
+      // test
+      val result = BackendRequest.toTuple(r)
+
+      // check
+      result._1 shouldBe contributions
+      result._2 shouldBe Some(2012)
+      result._3 shouldBe Some(false)
+    }
+
+    "toRequest" in {
+      // set up
+      val contributions = List(Contribution(2010,123), Contribution(2011,456))
+      val r = CalculationRequest(contributions, Some(2012), Some(false))
+
+      // test
+      val result = BackendRequest.toRequest(contributions, Some(2012), Some(false))
+
+      // check
+      result shouldBe r
+    }
+  }
+}


### PR DESCRIPTION
Send calculation settings (i.e. year to start carry forwards) as a request object wrapping contributions. 